### PR TITLE
Add switching for additional C++ files

### DIFF
--- a/lua/pear/init.lua
+++ b/lua/pear/init.lua
@@ -3,10 +3,10 @@ local M = {}
 M.jump_pair = function()
     local ext = vim.fn.expand("%:e")
 
-    local source_exts = { "cpp", "c", "frag", "server.ts", "js", "ts", "jsx", "tsx", "py", "java", "rs", "go", "css",
+    local source_exts = { "c", "cpp", "cc", "cxx", "frag", "server.ts", "js", "ts", "jsx", "tsx", "py", "java", "rs", "go", "css",
         "scss", "less" }
 
-    local header_exts = { "h", "hpp", "hh", "vert", "svelte", "html", "vue", "component.ts", "component.js", "types.ts",
+    local header_exts = { "h", "hpp", "hh", "hxx", "vert", "svelte", "html", "vue", "component.ts", "component.js", "types.ts",
         "interface.ts", "d.ts", "test.py", "spec.ts", "spec.js", "test.js", "test.ts" }
 
     local target_exts = nil


### PR DESCRIPTION
I don't think I'll actually use your plugin (since `clangd` has [header/source switching support](https://clangd.llvm.org/extensions#switch-between-sourceheader)) and I'd rather use that feature.

I, however, decided after watching your video that you needed additional C++ files.

Go play some Outer Wilds if you haven't ::) and if you think about your vim config, touch some grass